### PR TITLE
Feature/dispatch repository event

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -6,7 +6,7 @@ extends: default
 
 rules:
   line-length:
-    max: 120  # Allow up to 100 characters per line (default is 80)
+    max: 120  # Allow up to 120 characters per line (default is 80)
 
   # Disable truthy rule for GitHub Actions workflows
   truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,9 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 ## [1.2.0] - 2026-03-25
 
 ### Added
-- `build-repo-matrix` composite action: converts a newline-separated list of
-  `owner/repo` strings into a compact JSON array suitable for a GitHub Actions
-  matrix strategy. Outputs a single `matrix` value consumed directly by
-  `strategy.matrix`.
-- `dispatch-repository-event` composite action: sends a `repository_dispatch`
-  event to a target repository via the GitHub API. Exposes `status_code` and
-  `success` outputs so callers can gate subsequent steps on acceptance.
-- `wait-for-downstream-run` composite action: polls a target repository for a
-  `repository_dispatch`-triggered workflow run created at or after a supplied
-  timestamp and waits for it to reach a terminal state. Exposes `run_id`,
-  `run_url`, `conclusion`, and `timed_out` outputs.
-
+- `build-repo-matrix` composite action: converts a newline-separated list of `owner/repo` strings into a compact JSON array suitable for a GitHub Actions matrix strategy. Outputs a single `matrix` value consumed directly by `strategy.matrix`.
+- `dispatch-repository-event` composite action: sends a `repository_dispatch` event to a target repository via the GitHub API. Exposes `status_code` and `success` outputs so callers can gate subsequent steps on acceptance.
+- `wait-for-downstream-run` composite action: polls a target repository for a `repository_dispatch`-triggered workflow run created at or after a supplied timestamp and waits for it to reach a terminal state. Exposes `run_id`, `run_url`, `conclusion`, and `timed_out` outputs.
 
 ## [1.1.2] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-03-25
+
+### Added
+- `build-repo-matrix` composite action: converts a newline-separated list of
+  `owner/repo` strings into a compact JSON array suitable for a GitHub Actions
+  matrix strategy. Outputs a single `matrix` value consumed directly by
+  `strategy.matrix`.
+- `dispatch-repository-event` composite action: sends a `repository_dispatch`
+  event to a target repository via the GitHub API. Exposes `status_code` and
+  `success` outputs so callers can gate subsequent steps on acceptance.
+- `wait-for-downstream-run` composite action: polls a target repository for a
+  `repository_dispatch`-triggered workflow run created at or after a supplied
+  timestamp and waits for it to reach a terminal state. Exposes `run_id`,
+  `run_url`, `conclusion`, and `timed_out` outputs.
+
+
 ## [1.1.2] - 2026-03-24
 
 ### Fixed
@@ -95,6 +111,7 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 ### Security
 - Added certificate cleanup support and explicit guidance to remove imported signing certificates after use.
 
+[1.2.0]: https://github.com/mennotech/github-actions/releases/tag/v1.2.0
 [1.1.2]: https://github.com/mennotech/github-actions/releases/tag/v1.1.2
 [1.1.1]: https://github.com/mennotech/github-actions/releases/tag/v1.1.1
 [1.1.0]: https://github.com/mennotech/github-actions/releases/tag/v1.1.0

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ steps:
 
 ## Available Actions
 
+### Workflow Orchestration Actions (Cross-Platform)
+
+| Action | Purpose | Documentation |
+|--------|---------|---------------|
+| [`build-repo-matrix`](./build-repo-matrix/) | Convert newline-separated `owner/repo` list into JSON array for GitHub Actions matrix strategy | [📖 Details](./build-repo-matrix/action.yml) |
+| [`dispatch-repository-event`](./dispatch-repository-event/) | Send `repository_dispatch` event to trigger downstream workflows | [📖 Details](./dispatch-repository-event/action.yml) |
+| [`wait-for-downstream-run`](./wait-for-downstream-run/) | Poll and wait for downstream `repository_dispatch`-triggered workflow run to complete | [📖 Details](./wait-for-downstream-run/action.yml) |
+
 ### Platform-Specific Actions (Windows)
 > **Migration Complete**: Actions have been renamed with `-windows` suffix to support future cross-platform expansion.
 

--- a/build-repo-matrix/Build-RepoMatrix.ps1
+++ b/build-repo-matrix/Build-RepoMatrix.ps1
@@ -44,8 +44,14 @@ if (-not [string]::IsNullOrWhiteSpace($DownstreamRepos)) {
         }
 
         $parts = $repo -split '/'
+        if ($parts.Count -ne 2 -or
+            [string]::IsNullOrWhiteSpace($parts[0]) -or
+            [string]::IsNullOrWhiteSpace($parts[1])) {
+            throw "Invalid downstream repo entry '$repo'. Expected format 'owner/repo'."
+        }
+
         $owner = $parts[0]
-        $name = $parts[-1]
+        $name  = $parts[1]
 
         $matrix += [pscustomobject]@{
             owner = $owner

--- a/build-repo-matrix/Build-RepoMatrix.ps1
+++ b/build-repo-matrix/Build-RepoMatrix.ps1
@@ -34,29 +34,31 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+if ([string]::IsNullOrWhiteSpace($DownstreamRepos)) {
+    throw "DownstreamRepos input is required and cannot be empty or whitespace. Provide at least one 'owner/repo' entry."
+}
+
 $matrix = @()
 
-if (-not [string]::IsNullOrWhiteSpace($DownstreamRepos)) {
-    foreach ($line in ($DownstreamRepos -split "`r?`n")) {
-        $repo = $line.Trim()
-        if ([string]::IsNullOrWhiteSpace($repo)) {
-            continue
-        }
+foreach ($line in ($DownstreamRepos -split "`r?`n")) {
+    $repo = $line.Trim()
+    if ([string]::IsNullOrWhiteSpace($repo)) {
+        continue
+    }
 
-        $parts = $repo -split '/'
-        if ($parts.Count -ne 2 -or
-            [string]::IsNullOrWhiteSpace($parts[0]) -or
-            [string]::IsNullOrWhiteSpace($parts[1])) {
-            throw "Invalid downstream repo entry '$repo'. Expected format 'owner/repo'."
-        }
+    $parts = $repo -split '/'
+    if ($parts.Count -ne 2 -or
+        [string]::IsNullOrWhiteSpace($parts[0]) -or
+        [string]::IsNullOrWhiteSpace($parts[1])) {
+        throw "Invalid downstream repo entry '$repo'. Expected format 'owner/repo'."
+    }
 
-        $owner = $parts[0]
-        $name  = $parts[1]
+    $owner = $parts[0]
+    $name  = $parts[1]
 
-        $matrix += [pscustomobject]@{
-            owner = $owner
-            repo  = $name
-        }
+    $matrix += [pscustomobject]@{
+        owner = $owner
+        repo  = $name
     }
 }
 

--- a/build-repo-matrix/Build-RepoMatrix.ps1
+++ b/build-repo-matrix/Build-RepoMatrix.ps1
@@ -1,0 +1,58 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Converts a newline-separated list of org/repo strings into a compact JSON
+    array suitable for use as a GitHub Actions matrix strategy.
+
+.DESCRIPTION
+    Reads the DOWNSTREAM_REPOS environment variable (or the DownstreamRepos
+    parameter), splits by newline, trims whitespace, discards blank lines, and
+    emits a compact JSON array of {owner, repo} objects to GITHUB_OUTPUT.
+
+    Each entry must be in the form "owner/repo". The owner is the first
+    path segment and the repo name is the last path segment.
+
+.PARAMETER DownstreamRepos
+    Newline-separated list of org/repo strings.
+    Defaults to the DOWNSTREAM_REPOS environment variable.
+
+.EXAMPLE
+    Build-RepoMatrix.ps1
+    # Reads $env:DOWNSTREAM_REPOS and writes matrix=... to $env:GITHUB_OUTPUT
+
+.EXAMPLE
+    $env:DOWNSTREAM_REPOS = "myorg/repo-a`nmyorg/repo-b"
+    Build-RepoMatrix.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$DownstreamRepos = $env:DOWNSTREAM_REPOS
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$matrix = @()
+
+if (-not [string]::IsNullOrWhiteSpace($DownstreamRepos)) {
+    foreach ($line in ($DownstreamRepos -split "`r?`n")) {
+        $repo = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($repo)) {
+            continue
+        }
+
+        $parts = $repo -split '/'
+        $owner = $parts[0]
+        $name = $parts[-1]
+
+        $matrix += [pscustomobject]@{
+            owner = $owner
+            repo  = $name
+        }
+    }
+}
+
+$matrixJson = ConvertTo-Json -InputObject @($matrix) -Compress -Depth 3
+"matrix=$matrixJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append

--- a/build-repo-matrix/action.yml
+++ b/build-repo-matrix/action.yml
@@ -1,0 +1,51 @@
+---
+name: 'Build Repo Matrix'
+description: >
+  Converts a newline-separated list of org/repo strings into a compact JSON array
+  suitable for use as a GitHub Actions matrix: [{"owner":..., "repo":...}].
+
+inputs:
+  downstream_repos:
+    description: 'Newline-separated list of org/repo strings.'
+    required: true
+
+outputs:
+  matrix:
+    description: 'Compact JSON array of {owner, repo} objects.'
+    value: ${{ steps.build.outputs.matrix }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Build matrix
+      id: build
+      shell: pwsh
+      env:
+        DOWNSTREAM_REPOS: ${{ inputs.downstream_repos }}
+      run: |
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
+
+        $matrix = @()
+        $downstreamRepos = $env:DOWNSTREAM_REPOS
+
+        if (-not [string]::IsNullOrWhiteSpace($downstreamRepos)) {
+          foreach ($line in ($downstreamRepos -split "`r?`n")) {
+            $repo = $line.Trim()
+            if ([string]::IsNullOrWhiteSpace($repo)) {
+              continue
+            }
+
+            $parts = $repo -split '/'
+            $owner = $parts[0]
+            $name = $parts[-1]
+
+            $matrix += [pscustomobject]@{
+              owner = $owner
+              repo  = $name
+            }
+          }
+        }
+
+        $matrixJson = $matrix | ConvertTo-Json -Compress -Depth 3
+        "matrix=$matrixJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append

--- a/build-repo-matrix/action.yml
+++ b/build-repo-matrix/action.yml
@@ -47,5 +47,5 @@ runs:
           }
         }
 
-        $matrixJson = $matrix | ConvertTo-Json -Compress -Depth 3
+        $matrixJson = ConvertTo-Json -InputObject @($matrix) -Compress -Depth 3
         "matrix=$matrixJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append

--- a/build-repo-matrix/action.yml
+++ b/build-repo-matrix/action.yml
@@ -23,29 +23,4 @@ runs:
       env:
         DOWNSTREAM_REPOS: ${{ inputs.downstream_repos }}
       run: |
-        Set-StrictMode -Version Latest
-        $ErrorActionPreference = 'Stop'
-
-        $matrix = @()
-        $downstreamRepos = $env:DOWNSTREAM_REPOS
-
-        if (-not [string]::IsNullOrWhiteSpace($downstreamRepos)) {
-          foreach ($line in ($downstreamRepos -split "`r?`n")) {
-            $repo = $line.Trim()
-            if ([string]::IsNullOrWhiteSpace($repo)) {
-              continue
-            }
-
-            $parts = $repo -split '/'
-            $owner = $parts[0]
-            $name = $parts[-1]
-
-            $matrix += [pscustomobject]@{
-              owner = $owner
-              repo  = $name
-            }
-          }
-        }
-
-        $matrixJson = ConvertTo-Json -InputObject @($matrix) -Compress -Depth 3
-        "matrix=$matrixJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+        & "${{ github.action_path }}/Build-RepoMatrix.ps1"

--- a/dispatch-repository-event/Send-RepositoryDispatch.ps1
+++ b/dispatch-repository-event/Send-RepositoryDispatch.ps1
@@ -84,6 +84,11 @@ catch {
     throw "Input 'client_payload' must be valid JSON. Error: $($_.Exception.Message)"
 }
 
+if ($clientPayloadObject -isnot [PSCustomObject]) {
+    $receivedType = if ($null -eq $clientPayloadObject) { 'null' } else { $clientPayloadObject.GetType().Name }
+    throw "Input 'client_payload' must be a JSON object (e.g., '{}/{}'), not a $receivedType"
+}
+
 $requestBody = @{
     event_type     = $EventType
     client_payload = $clientPayloadObject

--- a/dispatch-repository-event/Send-RepositoryDispatch.ps1
+++ b/dispatch-repository-event/Send-RepositoryDispatch.ps1
@@ -60,6 +60,23 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Validate required inputs
+if ([string]::IsNullOrWhiteSpace($Token)) {
+    throw "Missing required input: 'token' (or environment variable DISPATCH_TOKEN)"
+}
+if ([string]::IsNullOrWhiteSpace($Owner)) {
+    throw "Missing required input: 'owner' (or environment variable OWNER)"
+}
+if ([string]::IsNullOrWhiteSpace($Repo)) {
+    throw "Missing required input: 'repo' (or environment variable REPO)"
+}
+if ([string]::IsNullOrWhiteSpace($EventType)) {
+    throw "Missing required input: 'event_type' (or environment variable EVENT_TYPE)"
+}
+if ($EventType.Length -gt 100) {
+    throw "Input 'event_type' must not exceed 100 characters (got $($EventType.Length))"
+}
+
 try {
     $clientPayloadObject = $ClientPayload | ConvertFrom-Json -Depth 100
 }

--- a/dispatch-repository-event/Send-RepositoryDispatch.ps1
+++ b/dispatch-repository-event/Send-RepositoryDispatch.ps1
@@ -1,0 +1,104 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Sends a repository_dispatch event to a GitHub repository.
+
+.DESCRIPTION
+    Posts a repository_dispatch event to the GitHub API and writes the HTTP
+    status code and a boolean success flag to GITHUB_OUTPUT.
+
+    Requires a token with Contents: write permission on the target repository.
+
+.PARAMETER Token
+    GitHub token (or GitHub App token) with Contents: write on the target
+    repository. Defaults to the DISPATCH_TOKEN environment variable.
+
+.PARAMETER Owner
+    Target organization or user account. Defaults to the OWNER environment
+    variable.
+
+.PARAMETER Repo
+    Target repository name (without the owner prefix). Defaults to the REPO
+    environment variable.
+
+.PARAMETER EventType
+    The repository_dispatch event type string (max 100 chars). Defaults to the
+    EVENT_TYPE environment variable.
+
+.PARAMETER ClientPayload
+    JSON object string to send as client_payload. Must be valid JSON.
+    Defaults to the CLIENT_PAYLOAD environment variable, or '{}' if unset.
+
+.EXAMPLE
+    Send-RepositoryDispatch.ps1
+    # Reads all inputs from environment variables
+
+.EXAMPLE
+    Send-RepositoryDispatch.ps1 -Owner myorg -Repo myrepo -EventType deploy
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Token = $env:DISPATCH_TOKEN,
+
+    [Parameter()]
+    [string]$Owner = $env:OWNER,
+
+    [Parameter()]
+    [string]$Repo = $env:REPO,
+
+    [Parameter()]
+    [string]$EventType = $env:EVENT_TYPE,
+
+    [Parameter()]
+    [string]$ClientPayload = $(
+        if ($env:CLIENT_PAYLOAD) { $env:CLIENT_PAYLOAD } else { '{}' }
+    )
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+try {
+    $clientPayloadObject = $ClientPayload | ConvertFrom-Json -Depth 100
+}
+catch {
+    throw "Input 'client_payload' must be valid JSON. Error: $($_.Exception.Message)"
+}
+
+$requestBody = @{
+    event_type     = $EventType
+    client_payload = $clientPayloadObject
+} | ConvertTo-Json -Compress -Depth 100
+
+$headers = @{
+    Accept                 = 'application/vnd.github+json'
+    Authorization          = "Bearer $Token"
+    'X-GitHub-Api-Version' = '2022-11-28'
+}
+
+$uri = "https://api.github.com/repos/$Owner/$Repo/dispatches"
+$iwrParams = @{
+    Method      = 'Post'
+    Uri         = $uri
+    Headers     = $headers
+    Body        = $requestBody
+    ContentType = 'application/json'
+}
+$response = Invoke-WebRequest @iwrParams -SkipHttpErrorCheck
+$statusCode = [int]$response.StatusCode
+
+"status_code=$statusCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+
+if ($statusCode -eq 204) {
+    Write-Host "Dispatch accepted (HTTP 204) for $Owner/$Repo"
+    'success=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+}
+else {
+    Write-Host "Dispatch FAILED (HTTP $statusCode) for $Owner/${Repo}:"
+    if (-not [string]::IsNullOrWhiteSpace($response.Content)) {
+        Write-Host $response.Content
+    }
+    'success=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+}

--- a/dispatch-repository-event/action.yml
+++ b/dispatch-repository-event/action.yml
@@ -53,48 +53,4 @@ runs:
         EVENT_TYPE: ${{ inputs.event_type }}
         CLIENT_PAYLOAD: ${{ inputs.client_payload }}
       run: |
-        Set-StrictMode -Version Latest
-        $ErrorActionPreference = 'Stop'
-
-        try {
-          $clientPayloadObject = $env:CLIENT_PAYLOAD | ConvertFrom-Json -Depth 100
-        }
-        catch {
-          throw "Input 'client_payload' must be valid JSON. Error: $($_.Exception.Message)"
-        }
-
-        $requestBody = @{
-          event_type     = $env:EVENT_TYPE
-          client_payload = $clientPayloadObject
-        } | ConvertTo-Json -Compress -Depth 100
-
-        $headers = @{
-          Accept                 = 'application/vnd.github+json'
-          Authorization          = "Bearer $($env:DISPATCH_TOKEN)"
-          'X-GitHub-Api-Version' = '2022-11-28'
-        }
-
-        $uri = "https://api.github.com/repos/$($env:OWNER)/$($env:REPO)/dispatches"
-        $iwrParams = @{
-          Method      = 'Post'
-          Uri         = $uri
-          Headers     = $headers
-          Body        = $requestBody
-          ContentType = 'application/json'
-        }
-        $response = Invoke-WebRequest @iwrParams -SkipHttpErrorCheck
-        $statusCode = [int]$response.StatusCode
-
-        "status_code=$statusCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
-
-        if ($statusCode -eq 204) {
-          Write-Host "Dispatch accepted (HTTP 204) for $($env:OWNER)/$($env:REPO)"
-          'success=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
-        }
-        else {
-          Write-Host "Dispatch FAILED (HTTP $statusCode) for $($env:OWNER)/$($env:REPO):"
-          if (-not [string]::IsNullOrWhiteSpace($response.Content)) {
-            Write-Host $response.Content
-          }
-          'success=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
-        }
+        & "${{ github.action_path }}/Send-RepositoryDispatch.ps1"

--- a/dispatch-repository-event/action.yml
+++ b/dispatch-repository-event/action.yml
@@ -45,7 +45,7 @@ runs:
   steps:
     - name: Send dispatch event
       id: dispatch
-      shell: bash
+      shell: pwsh
       env:
         DISPATCH_TOKEN: ${{ inputs.token }}
         OWNER: ${{ inputs.owner }}
@@ -53,30 +53,41 @@ runs:
         EVENT_TYPE: ${{ inputs.event_type }}
         CLIENT_PAYLOAD: ${{ inputs.client_payload }}
       run: |
-        set -euo pipefail
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
 
-        request_body="$(jq -cn \
-          --arg event_type "${EVENT_TYPE}" \
-          --argjson client_payload "${CLIENT_PAYLOAD}" \
-          '{event_type: $event_type, client_payload: $client_payload}')"
+        try {
+          $clientPayloadObject = $env:CLIENT_PAYLOAD | ConvertFrom-Json -Depth 100
+        }
+        catch {
+          throw "Input 'client_payload' must be valid JSON. Error: $($_.Exception.Message)"
+        }
 
-        response_file="$(mktemp)"
-        status_code="$(curl -sS -o "${response_file}" -w "%{http_code}" -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          "https://api.github.com/repos/${OWNER}/${REPO}/dispatches" \
-          -d "${request_body}")"
+        $requestBody = @{
+          event_type     = $env:EVENT_TYPE
+          client_payload = $clientPayloadObject
+        } | ConvertTo-Json -Compress -Depth 100
 
-        echo "status_code=${status_code}" >> "${GITHUB_OUTPUT}"
+        $headers = @{
+          Accept                 = 'application/vnd.github+json'
+          Authorization          = "Bearer $($env:DISPATCH_TOKEN)"
+          'X-GitHub-Api-Version' = '2022-11-28'
+        }
 
-        if [ "${status_code}" = "204" ]; then
-          echo "Dispatch accepted (HTTP 204) for ${OWNER}/${REPO}"
-          echo "success=true" >> "${GITHUB_OUTPUT}"
-        else
-          echo "Dispatch FAILED (HTTP ${status_code}) for ${OWNER}/${REPO}:"
-          cat "${response_file}"
-          echo "success=false" >> "${GITHUB_OUTPUT}"
-        fi
+        $uri = "https://api.github.com/repos/$($env:OWNER)/$($env:REPO)/dispatches"
+        $response = Invoke-WebRequest -Method Post -Uri $uri -Headers $headers -Body $requestBody -ContentType 'application/json' -SkipHttpErrorCheck
+        $statusCode = [int]$response.StatusCode
 
-        rm -f "${response_file}"
+        "status_code=$statusCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+
+        if ($statusCode -eq 204) {
+          Write-Host "Dispatch accepted (HTTP 204) for $($env:OWNER)/$($env:REPO)"
+          'success=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+        }
+        else {
+          Write-Host "Dispatch FAILED (HTTP $statusCode) for $($env:OWNER)/$($env:REPO):"
+          if (-not [string]::IsNullOrWhiteSpace($response.Content)) {
+            Write-Host $response.Content
+          }
+          'success=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+        }

--- a/dispatch-repository-event/action.yml
+++ b/dispatch-repository-event/action.yml
@@ -75,7 +75,14 @@ runs:
         }
 
         $uri = "https://api.github.com/repos/$($env:OWNER)/$($env:REPO)/dispatches"
-        $response = Invoke-WebRequest -Method Post -Uri $uri -Headers $headers -Body $requestBody -ContentType 'application/json' -SkipHttpErrorCheck
+        $iwrParams = @{
+          Method      = 'Post'
+          Uri         = $uri
+          Headers     = $headers
+          Body        = $requestBody
+          ContentType = 'application/json'
+        }
+        $response = Invoke-WebRequest @iwrParams -SkipHttpErrorCheck
         $statusCode = [int]$response.StatusCode
 
         "status_code=$statusCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append

--- a/dispatch-repository-event/action.yml
+++ b/dispatch-repository-event/action.yml
@@ -1,0 +1,82 @@
+---
+name: 'Dispatch Repository Event'
+description: >
+  Send a repository_dispatch event to a GitHub repository and report the HTTP
+  status. Requires a token with Contents: write on the target repository.
+
+inputs:
+  token:
+    description: >
+      GitHub token (or GitHub App token) with Contents: write on the target
+      repository.
+    required: true
+
+  owner:
+    description: 'Target organization or user account.'
+    required: true
+
+  repo:
+    description: 'Target repository name (without the owner prefix).'
+    required: true
+
+  event_type:
+    description: 'The repository_dispatch event type string (max 100 chars).'
+    required: true
+
+  client_payload:
+    description: >
+      JSON object string to send as client_payload. Must be valid JSON.
+      Defaults to an empty object.
+    required: false
+    default: '{}'
+
+outputs:
+  status_code:
+    description: 'HTTP status code returned by the GitHub API dispatch endpoint.'
+    value: ${{ steps.dispatch.outputs.status_code }}
+
+  success:
+    description: >
+      'true' if the dispatch was accepted (HTTP 204), 'false' otherwise.
+    value: ${{ steps.dispatch.outputs.success }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Send dispatch event
+      id: dispatch
+      shell: bash
+      env:
+        DISPATCH_TOKEN: ${{ inputs.token }}
+        OWNER: ${{ inputs.owner }}
+        REPO: ${{ inputs.repo }}
+        EVENT_TYPE: ${{ inputs.event_type }}
+        CLIENT_PAYLOAD: ${{ inputs.client_payload }}
+      run: |
+        set -euo pipefail
+
+        request_body="$(jq -cn \
+          --arg event_type "${EVENT_TYPE}" \
+          --argjson client_payload "${CLIENT_PAYLOAD}" \
+          '{event_type: $event_type, client_payload: $client_payload}')"
+
+        response_file="$(mktemp)"
+        status_code="$(curl -sS -o "${response_file}" -w "%{http_code}" -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/${OWNER}/${REPO}/dispatches" \
+          -d "${request_body}")"
+
+        echo "status_code=${status_code}" >> "${GITHUB_OUTPUT}"
+
+        if [ "${status_code}" = "204" ]; then
+          echo "Dispatch accepted (HTTP 204) for ${OWNER}/${REPO}"
+          echo "success=true" >> "${GITHUB_OUTPUT}"
+        else
+          echo "Dispatch FAILED (HTTP ${status_code}) for ${OWNER}/${REPO}:"
+          cat "${response_file}"
+          echo "success=false" >> "${GITHUB_OUTPUT}"
+        fi
+
+        rm -f "${response_file}"

--- a/wait-for-downstream-run/Wait-ForDownstreamRun.ps1
+++ b/wait-for-downstream-run/Wait-ForDownstreamRun.ps1
@@ -1,0 +1,124 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Polls a repository for a repository_dispatch workflow run and waits for completion.
+
+.DESCRIPTION
+    Queries the GitHub Actions runs API for repository_dispatch runs created at or
+    after a specified timestamp. Waits until a matching run appears and reaches
+    a completed status or a timeout is reached.
+
+    Writes run_id, run_url, conclusion, and timed_out to GITHUB_OUTPUT.
+
+.PARAMETER Token
+    GitHub token (or GitHub App token) with Actions: read on the target
+    repository. Defaults to POLL_TOKEN environment variable.
+
+.PARAMETER Owner
+    Target organization or user account. Defaults to OWNER environment variable.
+
+.PARAMETER Repo
+    Target repository name (without owner prefix). Defaults to REPO environment
+    variable.
+
+.PARAMETER DispatchedAt
+    ISO 8601 UTC timestamp. Only runs created at or after this time are
+    considered. Defaults to DISPATCHED_AT environment variable.
+
+.PARAMETER TimeoutSeconds
+    Maximum number of seconds to wait for the run to appear and complete.
+    Defaults to TIMEOUT_SECONDS environment variable or 1200.
+
+.PARAMETER PollIntervalSeconds
+    Number of seconds between polling attempts. Defaults to
+    POLL_INTERVAL_SECONDS environment variable or 20.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Token = $env:POLL_TOKEN,
+
+    [Parameter()]
+    [string]$Owner = $env:OWNER,
+
+    [Parameter()]
+    [string]$Repo = $env:REPO,
+
+    [Parameter()]
+    [string]$DispatchedAt = $env:DISPATCHED_AT,
+
+    [Parameter()]
+    [int]$TimeoutSeconds = $(if ($env:TIMEOUT_SECONDS) { [int]$env:TIMEOUT_SECONDS } else { 1200 }),
+
+    [Parameter()]
+    [int]$PollIntervalSeconds = $(if ($env:POLL_INTERVAL_SECONDS) { [int]$env:POLL_INTERVAL_SECONDS } else { 20 })
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$timeoutAt = (Get-Date).ToUniversalTime().AddSeconds($TimeoutSeconds)
+$foundRun = $false
+$runFinished = $false
+$runId = ''
+$runUrl = ''
+$conclusion = ''
+
+$headers = @{
+    Accept                 = 'application/vnd.github+json'
+    Authorization          = "Bearer $Token"
+    'X-GitHub-Api-Version' = '2022-11-28'
+}
+
+while ((Get-Date).ToUniversalTime() -lt $timeoutAt) {
+    $uri = "https://api.github.com/repos/$Owner/$Repo/actions/runs?event=repository_dispatch&per_page=50"
+    $runsResponse = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+
+    $selectedRun = $null
+    if ($null -ne $runsResponse.workflow_runs) {
+        $selectedRun = $runsResponse.workflow_runs |
+            Where-Object { $_.created_at -ge $DispatchedAt } |
+            Sort-Object -Property created_at -Descending |
+            Select-Object -First 1
+    }
+
+    if ($null -ne $selectedRun) {
+        $foundRun = $true
+        $runId = [string]$selectedRun.id
+        $runName = [string]$selectedRun.name
+        $runStatus = [string]$selectedRun.status
+        $runConclusion = if ($null -eq $selectedRun.conclusion) { 'null' } else { [string]$selectedRun.conclusion }
+        $runUrl = [string]$selectedRun.html_url
+
+        Write-Host "Run found: id=$runId name=$runName status=$runStatus conclusion=$runConclusion"
+        Write-Host "Run URL: $runUrl"
+
+        if ($runStatus -eq 'completed') {
+            $runFinished = $true
+            $conclusion = $runConclusion
+            break
+        }
+    }
+    else {
+        $remaining = [int][Math]::Ceiling(($timeoutAt - (Get-Date).ToUniversalTime()).TotalSeconds)
+        Write-Host "No run found yet for $Owner/$Repo; waiting ${PollIntervalSeconds}s (${remaining}s remaining)"
+    }
+
+    Start-Sleep -Seconds $PollIntervalSeconds
+}
+
+$timedOut = 'false'
+if (-not $foundRun) {
+    Write-Host "Timed out waiting for a matching run to appear for $Owner/$Repo"
+    $timedOut = 'true'
+}
+elseif (-not $runFinished) {
+    Write-Host "Timed out waiting for run $runId to complete for $Owner/$Repo"
+    $timedOut = 'true'
+}
+
+"run_id=$runId" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+"run_url=$runUrl" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+"conclusion=$conclusion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+"timed_out=$timedOut" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append

--- a/wait-for-downstream-run/Wait-ForDownstreamRun.ps1
+++ b/wait-for-downstream-run/Wait-ForDownstreamRun.ps1
@@ -80,16 +80,27 @@ if ($PollIntervalSeconds -le 0) {
 
 # Parse DispatchedAt as UTC DateTime — fail fast if not valid ISO 8601
 $dispatchedAtUtc = $null
+$iso8601Formats = @(
+    'O',  # Round-trip: 2026-03-25T14:00:00.0000000+00:00
+    'o',  # Round-trip (lowercase): 2026-03-25T14:00:00.0000000+00:00
+    's',  # Sortable: 2026-03-25T14:00:00
+    'u',  # Universal sortable: 2026-03-25 14:00:00Z
+    'yyyy-MM-ddTHH:mm:ssZ',    # With literal Z for UTC
+    'yyyy-MM-ddTHH:mm:ss.fffffffZ',  # With fractional seconds and Z
+    'yyyy-MM-ddTHH:mm:sszzz',  # With timezone offset
+    'yyyy-MM-ddTHH:mm:ss.fffffffzzz'  # With fractional seconds and timezone offset
+)
 try {
-    $dispatchedAtUtc = [System.DateTimeOffset]::Parse(
+    $dispatchedAtUtc = [System.DateTimeOffset]::ParseExact(
         $DispatchedAt,
+        $iso8601Formats,
         [System.Globalization.CultureInfo]::InvariantCulture,
         [System.Globalization.DateTimeStyles]::AssumeUniversal -bor
         [System.Globalization.DateTimeStyles]::AdjustToUniversal
     ).UtcDateTime
 }
 catch {
-    throw "Input 'dispatched_at' is not a valid ISO 8601 timestamp: '$DispatchedAt'. Error: $($_.Exception.Message)"
+    throw "Input 'dispatched_at' must be in ISO 8601 format: '$DispatchedAt'. Error: $($_.Exception.Message)"
 }
 
 $timeoutAt = (Get-Date).ToUniversalTime().AddSeconds($TimeoutSeconds)
@@ -147,7 +158,7 @@ while ((Get-Date).ToUniversalTime() -lt $timeoutAt) {
             $runUrl = [string]$selectedRun.html_url
             $runName = [string]$selectedRun.name
             $runStatus = [string]$selectedRun.status
-            $runConclusion = if ($null -eq $selectedRun.conclusion) { 'null' } else { [string]$selectedRun.conclusion }
+            $runConclusion = if ($null -eq $selectedRun.conclusion) { '' } else { [string]$selectedRun.conclusion }
 
             Write-Host "Run found: id=$runId name=$runName status=$runStatus conclusion=$runConclusion"
             Write-Host "Run URL: $runUrl"
@@ -168,7 +179,7 @@ while ((Get-Date).ToUniversalTime() -lt $timeoutAt) {
         $uri = "https://api.github.com/repos/$Owner/$Repo/actions/runs/$runId"
         $run = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
         $runStatus = [string]$run.status
-        $runConclusion = if ($null -eq $run.conclusion) { 'null' } else { [string]$run.conclusion }
+        $runConclusion = if ($null -eq $run.conclusion) { '' } else { [string]$run.conclusion }
 
         Write-Host "Polling run ${runId}: status=$runStatus conclusion=$runConclusion"
 

--- a/wait-for-downstream-run/Wait-ForDownstreamRun.ps1
+++ b/wait-for-downstream-run/Wait-ForDownstreamRun.ps1
@@ -58,6 +58,40 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Validate required inputs
+if ([string]::IsNullOrWhiteSpace($Token)) {
+    throw "Missing required input: 'token' (or environment variable POLL_TOKEN)"
+}
+if ([string]::IsNullOrWhiteSpace($Owner)) {
+    throw "Missing required input: 'owner' (or environment variable OWNER)"
+}
+if ([string]::IsNullOrWhiteSpace($Repo)) {
+    throw "Missing required input: 'repo' (or environment variable REPO)"
+}
+if ([string]::IsNullOrWhiteSpace($DispatchedAt)) {
+    throw "Missing required input: 'dispatched_at' (or environment variable DISPATCHED_AT)"
+}
+if ($TimeoutSeconds -le 0) {
+    throw "Input 'timeout_seconds' must be greater than 0 (got $TimeoutSeconds)"
+}
+if ($PollIntervalSeconds -le 0) {
+    throw "Input 'poll_interval_seconds' must be greater than 0 (got $PollIntervalSeconds)"
+}
+
+# Parse DispatchedAt as UTC DateTime — fail fast if not valid ISO 8601
+$dispatchedAtUtc = $null
+try {
+    $dispatchedAtUtc = [System.DateTimeOffset]::Parse(
+        $DispatchedAt,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [System.Globalization.DateTimeStyles]::AssumeUniversal -bor
+        [System.Globalization.DateTimeStyles]::AdjustToUniversal
+    ).UtcDateTime
+}
+catch {
+    throw "Input 'dispatched_at' is not a valid ISO 8601 timestamp: '$DispatchedAt'. Error: $($_.Exception.Message)"
+}
+
 $timeoutAt = (Get-Date).ToUniversalTime().AddSeconds($TimeoutSeconds)
 $foundRun = $false
 $runFinished = $false
@@ -72,37 +106,77 @@ $headers = @{
 }
 
 while ((Get-Date).ToUniversalTime() -lt $timeoutAt) {
-    $uri = "https://api.github.com/repos/$Owner/$Repo/actions/runs?event=repository_dispatch&per_page=50"
-    $runsResponse = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+    if ([string]::IsNullOrEmpty($runId)) {
+        # Search for the matching run, paging until we pass dispatched_at
+        $selectedRun = $null
+        $page = 1
+        :pageLoop while ($true) {
+            $uri = "https://api.github.com/repos/$Owner/$Repo/actions/runs?event=repository_dispatch&per_page=100&page=$page"
+            $runsResponse = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+            $runs = $runsResponse.workflow_runs
+            if ($null -eq $runs -or $runs.Count -eq 0) {
+                break pageLoop
+            }
 
-    $selectedRun = $null
-    if ($null -ne $runsResponse.workflow_runs) {
-        $selectedRun = $runsResponse.workflow_runs |
-            Where-Object { $_.created_at -ge $DispatchedAt } |
-            Sort-Object -Property created_at -Descending |
-            Select-Object -First 1
+            # GitHub returns runs in descending created_at order by default
+            foreach ($run in $runs) {
+                $runCreatedAt = [System.DateTimeOffset]::Parse(
+                    $run.created_at,
+                    [System.Globalization.CultureInfo]::InvariantCulture,
+                    [System.Globalization.DateTimeStyles]::AssumeUniversal -bor
+                    [System.Globalization.DateTimeStyles]::AdjustToUniversal
+                ).UtcDateTime
+
+                if ($runCreatedAt -ge $dispatchedAtUtc) {
+                    # Runs are descending; each successive match is older, so the
+                    # last assignment will be the earliest run after dispatch.
+                    $selectedRun = $run
+                }
+                else {
+                    # Once we reach a run older than dispatched_at, stop paging
+                    break pageLoop
+                }
+            }
+
+            $page++
+        }
+
+        if ($null -ne $selectedRun) {
+            $foundRun = $true
+            $runId = [string]$selectedRun.id
+            $runUrl = [string]$selectedRun.html_url
+            $runName = [string]$selectedRun.name
+            $runStatus = [string]$selectedRun.status
+            $runConclusion = if ($null -eq $selectedRun.conclusion) { 'null' } else { [string]$selectedRun.conclusion }
+
+            Write-Host "Run found: id=$runId name=$runName status=$runStatus conclusion=$runConclusion"
+            Write-Host "Run URL: $runUrl"
+
+            if ($runStatus -eq 'completed') {
+                $runFinished = $true
+                $conclusion = $runConclusion
+                break
+            }
+        }
+        else {
+            $remaining = [int][Math]::Ceiling(($timeoutAt - (Get-Date).ToUniversalTime()).TotalSeconds)
+            Write-Host "No run found yet for $Owner/$Repo; waiting ${PollIntervalSeconds}s (${remaining}s remaining)"
+        }
     }
+    else {
+        # Run already identified — poll the single-run endpoint until it completes
+        $uri = "https://api.github.com/repos/$Owner/$Repo/actions/runs/$runId"
+        $run = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+        $runStatus = [string]$run.status
+        $runConclusion = if ($null -eq $run.conclusion) { 'null' } else { [string]$run.conclusion }
 
-    if ($null -ne $selectedRun) {
-        $foundRun = $true
-        $runId = [string]$selectedRun.id
-        $runName = [string]$selectedRun.name
-        $runStatus = [string]$selectedRun.status
-        $runConclusion = if ($null -eq $selectedRun.conclusion) { 'null' } else { [string]$selectedRun.conclusion }
-        $runUrl = [string]$selectedRun.html_url
-
-        Write-Host "Run found: id=$runId name=$runName status=$runStatus conclusion=$runConclusion"
-        Write-Host "Run URL: $runUrl"
+        Write-Host "Polling run ${runId}: status=$runStatus conclusion=$runConclusion"
 
         if ($runStatus -eq 'completed') {
             $runFinished = $true
             $conclusion = $runConclusion
             break
         }
-    }
-    else {
-        $remaining = [int][Math]::Ceiling(($timeoutAt - (Get-Date).ToUniversalTime()).TotalSeconds)
-        Write-Host "No run found yet for $Owner/$Repo; waiting ${PollIntervalSeconds}s (${remaining}s remaining)"
     }
 
     Start-Sleep -Seconds $PollIntervalSeconds

--- a/wait-for-downstream-run/action.yml
+++ b/wait-for-downstream-run/action.yml
@@ -1,0 +1,141 @@
+---
+name: 'Wait for Downstream Run'
+description: >
+  Poll a repository for a repository_dispatch workflow run that appeared at or
+  after a given timestamp and wait for it to complete. Requires a token with
+  Actions: read on the target repository.
+
+inputs:
+  token:
+    description: >
+      GitHub token (or GitHub App token) with Actions: read on the target
+      repository.
+    required: true
+
+  owner:
+    description: 'Target organization or user account.'
+    required: true
+
+  repo:
+    description: 'Target repository name (without the owner prefix).'
+    required: true
+
+  dispatched_at:
+    description: >
+      ISO 8601 UTC timestamp (e.g. 2026-03-25T14:00:00Z). Only workflow runs
+      created at or after this time are considered.
+    required: true
+
+  timeout_seconds:
+    description: >
+      Maximum number of seconds to wait for the run to appear and reach a
+      completed status.
+    required: false
+    default: '1200'
+
+  poll_interval_seconds:
+    description: 'Seconds to wait between polling attempts.'
+    required: false
+    default: '20'
+
+outputs:
+  run_id:
+    description: >
+      Numeric ID of the downstream workflow run found. Empty string if the
+      action timed out before a matching run appeared.
+    value: ${{ steps.poll.outputs.run_id }}
+
+  run_url:
+    description: >
+      HTML URL of the downstream workflow run. Empty string if timed out
+      before a matching run appeared.
+    value: ${{ steps.poll.outputs.run_url }}
+
+  conclusion:
+    description: >
+      Final conclusion of the completed run (success, failure, cancelled,
+      skipped, timed_out, action_required, neutral). Empty string if the
+      action timed out before the run completed.
+    value: ${{ steps.poll.outputs.conclusion }}
+
+  timed_out:
+    description: >
+      'true' if polling timed out before the run appeared or completed,
+      'false' otherwise.
+    value: ${{ steps.poll.outputs.timed_out }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Poll for run completion
+      id: poll
+      shell: bash
+      env:
+        POLL_TOKEN: ${{ inputs.token }}
+        OWNER: ${{ inputs.owner }}
+        REPO: ${{ inputs.repo }}
+        DISPATCHED_AT: ${{ inputs.dispatched_at }}
+        TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+        POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
+      run: |
+        set -euo pipefail
+
+        timeout_at=$(( $(date +%s) + TIMEOUT_SECONDS ))
+        found_run=0
+        run_finished=0
+        run_id=""
+        run_url=""
+        conclusion=""
+
+        while [ "$(date +%s)" -lt "${timeout_at}" ]; do
+          runs_json="$(curl -sS \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${POLL_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${OWNER}/${REPO}/actions/runs?event=repository_dispatch&per_page=50")"
+
+          selected_run="$(echo "${runs_json}" | jq -c --arg since "${DISPATCHED_AT}" '
+            .workflow_runs
+            | map(select(.created_at >= $since))
+            | sort_by(.created_at)
+            | reverse
+            | .[0] // empty
+          ')"
+
+          if [ -n "${selected_run}" ]; then
+            found_run=1
+            run_id="$(echo "${selected_run}" | jq -r '.id')"
+            run_name="$(echo "${selected_run}" | jq -r '.name')"
+            run_status="$(echo "${selected_run}" | jq -r '.status')"
+            run_conclusion="$(echo "${selected_run}" | jq -r '.conclusion // "null"')"
+            run_url="$(echo "${selected_run}" | jq -r '.html_url')"
+
+            echo "Run found: id=${run_id} name=${run_name} status=${run_status} conclusion=${run_conclusion}"
+            echo "Run URL: ${run_url}"
+
+            if [ "${run_status}" = "completed" ]; then
+              run_finished=1
+              conclusion="${run_conclusion}"
+              break
+            fi
+          else
+            remaining=$(( timeout_at - $(date +%s) ))
+            echo "No run found yet for ${OWNER}/${REPO}; waiting ${POLL_INTERVAL_SECONDS}s (${remaining}s remaining)"
+          fi
+
+          sleep "${POLL_INTERVAL_SECONDS}"
+        done
+
+        timed_out="false"
+        if [ "${found_run}" = "0" ]; then
+          echo "Timed out waiting for a matching run to appear for ${OWNER}/${REPO}"
+          timed_out="true"
+        elif [ "${run_finished}" = "0" ]; then
+          echo "Timed out waiting for run ${run_id} to complete for ${OWNER}/${REPO}"
+          timed_out="true"
+        fi
+
+        echo "run_id=${run_id}" >> "${GITHUB_OUTPUT}"
+        echo "run_url=${run_url}" >> "${GITHUB_OUTPUT}"
+        echo "conclusion=${conclusion}" >> "${GITHUB_OUTPUT}"
+        echo "timed_out=${timed_out}" >> "${GITHUB_OUTPUT}"

--- a/wait-for-downstream-run/action.yml
+++ b/wait-for-downstream-run/action.yml
@@ -69,7 +69,7 @@ runs:
   steps:
     - name: Poll for run completion
       id: poll
-      shell: bash
+      shell: pwsh
       env:
         POLL_TOKEN: ${{ inputs.token }}
         OWNER: ${{ inputs.owner }}
@@ -78,64 +78,4 @@ runs:
         TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
         POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
       run: |
-        set -euo pipefail
-
-        timeout_at=$(( $(date +%s) + TIMEOUT_SECONDS ))
-        found_run=0
-        run_finished=0
-        run_id=""
-        run_url=""
-        conclusion=""
-
-        while [ "$(date +%s)" -lt "${timeout_at}" ]; do
-          runs_json="$(curl -sS \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${POLL_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${OWNER}/${REPO}/actions/runs?event=repository_dispatch&per_page=50")"
-
-          selected_run="$(echo "${runs_json}" | jq -c --arg since "${DISPATCHED_AT}" '
-            .workflow_runs
-            | map(select(.created_at >= $since))
-            | sort_by(.created_at)
-            | reverse
-            | .[0] // empty
-          ')"
-
-          if [ -n "${selected_run}" ]; then
-            found_run=1
-            run_id="$(echo "${selected_run}" | jq -r '.id')"
-            run_name="$(echo "${selected_run}" | jq -r '.name')"
-            run_status="$(echo "${selected_run}" | jq -r '.status')"
-            run_conclusion="$(echo "${selected_run}" | jq -r '.conclusion // "null"')"
-            run_url="$(echo "${selected_run}" | jq -r '.html_url')"
-
-            echo "Run found: id=${run_id} name=${run_name} status=${run_status} conclusion=${run_conclusion}"
-            echo "Run URL: ${run_url}"
-
-            if [ "${run_status}" = "completed" ]; then
-              run_finished=1
-              conclusion="${run_conclusion}"
-              break
-            fi
-          else
-            remaining=$(( timeout_at - $(date +%s) ))
-            echo "No run found yet for ${OWNER}/${REPO}; waiting ${POLL_INTERVAL_SECONDS}s (${remaining}s remaining)"
-          fi
-
-          sleep "${POLL_INTERVAL_SECONDS}"
-        done
-
-        timed_out="false"
-        if [ "${found_run}" = "0" ]; then
-          echo "Timed out waiting for a matching run to appear for ${OWNER}/${REPO}"
-          timed_out="true"
-        elif [ "${run_finished}" = "0" ]; then
-          echo "Timed out waiting for run ${run_id} to complete for ${OWNER}/${REPO}"
-          timed_out="true"
-        fi
-
-        echo "run_id=${run_id}" >> "${GITHUB_OUTPUT}"
-        echo "run_url=${run_url}" >> "${GITHUB_OUTPUT}"
-        echo "conclusion=${conclusion}" >> "${GITHUB_OUTPUT}"
-        echo "timed_out=${timed_out}" >> "${GITHUB_OUTPUT}"
+        & "${{ github.action_path }}/Wait-ForDownstreamRun.ps1"


### PR DESCRIPTION
This pull request introduces three new composite GitHub Actions for orchestrating downstream repository workflows. The actions enable building a matrix of repositories, dispatching events to trigger downstream workflows, and waiting for those workflows to complete. These tools are designed to streamline complex CI/CD pipelines that span multiple repositories.

**New GitHub Actions for Downstream Workflow Orchestration:**

*Repository matrix construction:*
- Adds `build-repo-matrix/action.yml`, which converts a newline-separated list of `org/repo` strings into a compact JSON array suitable for use as a GitHub Actions matrix. This simplifies managing multi-repository workflows.

*Repository dispatch event:*
- Adds `dispatch-repository-event/action.yml`, providing an action to send a `repository_dispatch` event to a specified repository, with support for custom event types and payloads, and outputs to report the HTTP status and success.

*Downstream workflow run monitoring:*
- Adds `wait-for-downstream-run/action.yml`, which polls a repository for a workflow run triggered by a `repository_dispatch` event, waits for its completion, and outputs the run’s ID, URL, conclusion, and whether a timeout occurred.